### PR TITLE
Blacklisted passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-## Blacklisted words for third pary ads
+# Blacklisted words
+
+## Ad words
+
+Blacklisted words in ads on Google AdWords.
+
+## Passwords
+
+Blacklisted passwords, data from (10-million login combos.)[https://xato.net/passwords/ten-million-passwords/].
+
+Import blacklisted passwords (assumes a single string on each line):
+
+```SQL
+-- MySQL
+LOAD DATA INFILE '/~/passwords.txt'
+INTO TABLE passwords
+COLUMNS TERMINATED BY ','
+LINES TERMINATED BY '\n'
+IGNORE 0 LINES
+(value)
+SET passwords.id = NULL,
+created_at = NOW(),
+updated_at = NOW();
+```
+
+Performance (2012 MBP):
+
+* MySQL: Import of 5.2 million records in ~25 seconds
+* `Password.where()` in ~2 seconds
+* `Password.where('value like ?', "%#{params[:password]}%")` in ~3-4 seconds

--- a/app/controllers/validate_controller.rb
+++ b/app/controllers/validate_controller.rb
@@ -1,5 +1,32 @@
 class ValidateController < ApplicationController
+  PASSWORD_MAX_LIMIT     = 10_000
+  PASSWORDS_MAX_RETURNED = 100
+
   def validate_string
     render json: Word.blacklisted_words_in(params[:string], params[:type])
   end
+
+  def password
+    max_hits = params[:max_hits].blank? ? PASSWORDS_MAX_RETURNED : params[:max_hits].to_i
+    password = params[:password]
+
+    ensure_max_hits_conform!(max_hits) or return
+
+    render json: Password.
+      where('value like ?', "%#{password}%").
+      limit(max_hits).
+      map(&:value)
+  end
+
+  private 
+
+    def ensure_max_hits_conform!(max_hits)
+      if max_hits.zero? || max_hits > PASSWORD_MAX_LIMIT
+        error_message = "max_hits must be a number larger than 0 and less than #{PASSWORD_MAX_LIMIT}".freeze
+        render text: error_message, status: :bad_request
+        false
+      else
+        true
+      end
+    end
 end

--- a/app/models/password.rb
+++ b/app/models/password.rb
@@ -1,0 +1,2 @@
+class Password < ActiveRecord::Base
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   post 'validate/validate_string'
+
+  get 'validate/password'
 end

--- a/db/migrate/20150302180854_create_passwords.rb
+++ b/db/migrate/20150302180854_create_passwords.rb
@@ -1,0 +1,9 @@
+class CreatePasswords < ActiveRecord::Migration
+  def change
+    create_table :passwords do |t|
+      t.string :value
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150302221435_add_index_to_passwords_value_column.rb
+++ b/db/migrate/20150302221435_add_index_to_passwords_value_column.rb
@@ -1,0 +1,9 @@
+class AddIndexToPasswordsValueColumn < ActiveRecord::Migration
+  def up
+    add_index :passwords, :value
+  end
+
+  def down
+    remove_index :passwords, :value
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141212144435) do
+ActiveRecord::Schema.define(version: 20150302221435) do
 
-  create_table "words", force: true do |t|
+  create_table "passwords", force: :cascade do |t|
+    t.string   "value",      limit: 255
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+  end
+
+  add_index "passwords", ["value"], name: "index_passwords_on_value", using: :btree
+
+  create_table "words", force: :cascade do |t|
     t.string   "word",       limit: 255
     t.string   "word_type",  limit: 255
     t.datetime "created_at",             null: false


### PR DESCRIPTION
Adds support to scan through a list of blacklisted passwords. 

* Adds a new route `validate/password?`, which takes a required argument `password=`
* Creates a `Password` model with a column `value`.

Note that there is an import command for `MySQL` in README.md.

#### Performance

Runned on a 2012 MBP:

* MySQL: Import of 5.2 million records in ~25 seconds
* `Password.where()` in ~2 seconds
* `Password.where('value like ?', "%#{params[:password]}%")` in ~3-4 seconds

